### PR TITLE
Support to disable transport caching

### DIFF
--- a/rest/config.go
+++ b/rest/config.go
@@ -115,6 +115,9 @@ type Config struct {
 	// Dial specifies the dial function for creating unencrypted TCP connections.
 	Dial func(ctx context.Context, network, address string) (net.Conn, error)
 
+	// DisableTransportCache is set to true when caching should be disabled
+	DisableTransportCache bool
+
 	// Version forces a specific version to be used (if registered)
 	// Do we need this?
 	// Version string

--- a/rest/transport.go
+++ b/rest/transport.go
@@ -82,7 +82,8 @@ func (c *Config) TransportConfig() (*transport.Config, error) {
 			Groups:   c.Impersonate.Groups,
 			Extra:    c.Impersonate.Extra,
 		},
-		Dial: c.Dial,
+		Dial:                  c.Dial,
+		DisableTransportCache: c.DisableTransportCache,
 	}
 
 	if c.ExecProvider != nil && c.AuthProvider != nil {

--- a/transport/cache.go
+++ b/transport/cache.go
@@ -89,14 +89,17 @@ func (c *tlsTransportCache) get(config *Config) (http.RoundTripper, error) {
 		}).DialContext
 	}
 	// Cache a single transport for these options
-	c.transports[key] = utilnet.SetTransportDefaults(&http.Transport{
+	transport := utilnet.SetTransportDefaults(&http.Transport{
 		Proxy:               http.ProxyFromEnvironment,
 		TLSHandshakeTimeout: 10 * time.Second,
 		TLSClientConfig:     tlsConfig,
 		MaxIdleConnsPerHost: idleConnsPerHost,
 		DialContext:         dial,
 	})
-	return c.transports[key], nil
+	if !config.DisableTransportCache {
+		c.transports[key] = transport
+	}
+	return transport, nil
 }
 
 // tlsConfigKey returns a unique key for tls.Config objects returned from TLSConfigFor

--- a/transport/config.go
+++ b/transport/config.go
@@ -56,6 +56,9 @@ type Config struct {
 
 	// Dial specifies the dial function for creating unencrypted TCP connections.
 	Dial func(ctx context.Context, network, address string) (net.Conn, error)
+
+	// DisableTransportCache is set to true when caching should be disabled
+	DisableTransportCache bool
 }
 
 // ImpersonationConfig has all the available impersonation options
@@ -88,7 +91,7 @@ func (c *Config) HasCertAuth() bool {
 	return (len(c.TLS.CertData) != 0 || len(c.TLS.CertFile) != 0) && (len(c.TLS.KeyData) != 0 || len(c.TLS.KeyFile) != 0)
 }
 
-// HasCertCallbacks returns whether the configuration has certificate callback or not.
+// HasCertCallback returns whether the configuration has certificate callback or not.
 func (c *Config) HasCertCallback() bool {
 	return c.TLS.GetCert != nil
 }


### PR DESCRIPTION
Updates:
- Add `DisableTransportCache` to `rest.Config` struct
- Add `DisableTransportCache` to `transport.Config` struct
- Ignore the cache if `DisableTransportCache` is set to true by a client